### PR TITLE
tornando o metodo _openFile mais legivel

### DIFF
--- a/includes/0-config/ParserConfig.hpp
+++ b/includes/0-config/ParserConfig.hpp
@@ -39,8 +39,8 @@ class ParserConfig {
 		class WebServer							&_webServer;
 		std::vector<std::string>				_configServers;
 		std::map<std::string, _parseServerFunc>	_parseFuncs;
-
-		inline void			_openFile(const std::string &FilePath);
+		std::fstream        _openFile(const std::string &FilePath);
+        std::string         _getContentsFile(std::fstream file);
 		inline bool			_isCurlyBracketBalanced(std::string fileContent);
 		inline void			_splitServers();
 		inline void			_setServers();

--- a/src/0-config/ParserConfig.cpp
+++ b/src/0-config/ParserConfig.cpp
@@ -40,37 +40,42 @@ void ParserConfig::setFile(std::string file) {
 	this->_file = file;
 }
 
+
 // -Methods
 void ParserConfig::parseFile(const std::string &FilePath) {
-	this->_openFile(FilePath);
+	std::string contentsConfig;
+	
+	contentsConfig = this->_getContentsFile(this->_openFile(FilePath));
+	if(!this->_isCurlyBracketBalanced(contentsConfig))
+		throw std::runtime_error("Curly brackets are not balanced in the file " + FilePath);
+	this->setFile(contentsConfig);
 	this->_splitServers();
 	this->_setServers();
 	return ;
 }
 
+
 // -Private Methods
-inline void	ParserConfig::_openFile(const std::string &FilePath) {
-	std::ifstream		file;
-	std::string			fileString;
+inline std::fstream	ParserConfig::_openFile(const std::string &FilePath) {
+	std::fstream		file;
 	std::istringstream	iss;
 
-	fileString = "";
-	file.open(FilePath.c_str());
+	file.open(FilePath.c_str(), std::fstream::in);
 	if (!file.is_open()) {
-		throw std::runtime_error("Failed to open config file");
+		throw std::runtime_error("Failed to open config file " + FilePath);
 	}
-	std::string fileContent((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-	iss.str(fileContent);
-	for (std::string line; std::getline(iss, line); ) {
-		if (!line.empty()) {
-			fileString += line + '\n';
-		}
-	}
+	return file;
+}
 
-	if (!this->_isCurlyBracketBalanced(fileString)) {
-		throw std::runtime_error("Curly brackets are not balanced");
+std::string ParserConfig::_getContentsFile(std::fstream file){
+	std::string			fileString;
+	std::string 		line;
+
+	fileString = "";
+	while(std::getline(file, line)){
+		fileString += line + "\n";
 	}
-	this->setFile(fileString);
+	return fileString;
 }
 
 bool ParserConfig::_isCurlyBracketBalanced(std::string fileContent) {


### PR DESCRIPTION
Ao olhar o código notei que o metodo  _openFile do ParserConfig estava executando basicamente 3 ações: 

- abria o arquivo passado como parametro (principal);
-  capturava o conteudo do arquivo;
-  realizava uma validação para verificar se todos os colchetes que foram abertos também foram fechados.

como ele realizava todas essas ações dificultava a leitura do metodo, com as alterações propostas neste pr nos temos os seguintes ganhos:

- o metodo _openFile esta mais legível;
- caso seja necessário o metodo _openFile pode ser reutilizado em outros contextos;
- O metodo _getContentsFile que foi criado neste pr para capturar o conteudo do arquivo também pode ser utilizado em outros contextos caso necessario.